### PR TITLE
Do not convert a nil value into a blank hash.

### DIFF
--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -68,6 +68,8 @@ module Virtus
         attributes.each_with_object({}) do |(k, v), h|
           if v.is_a? Array
             h[k] = v.map { |v| hash_if_responds_or_value v }
+          elsif v.nil?
+            h[k] = v
           else
             h[k] = hash_if_responds_or_value v
           end


### PR DESCRIPTION
`nil` responds to `.to_h` and returns an empty hash. Thus, this method converts `nil` values to empty hashes, which is unexpected (and in my case, exception-throwing). 

This PR makes an exception for nil values.